### PR TITLE
Remove git-repo from image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,6 @@ RUN apt-get update && \
 # Supportive python tools for debugging, syntax checking and DB connectivity
 RUN pip3 install --upgrade pip ipdb flake8 python-swiftclient psycopg2 pymongo
 
-# Install git-repo
-RUN curl https://raw.githubusercontent.com/esrlabs/git-repo/stable/repo > /usr/bin/repo
-RUN chmod +x /usr/bin/repo
-
 # Get nodejs
 RUN mkdir /usr/lib/nodejs && \
     curl https://nodejs.org/dist/v6.11.3/node-v6.11.3-linux-x64.tar.xz | tar -xJ -C /usr/lib/nodejs && \


### PR DESCRIPTION
Including repo in the image causes us many problems. For one, we don't have access to it from Jenkins, so we can't build this image there. For another, for it to work properly, it requires us to add erroneous Git config to our image, which is messy.

Since it's only used in one project (ubuntu-core-docs) I think we should just include the binary in that project's codebase for now and remove it from here. Hopefully at some point we can remove it altogether.