### PR TITLE
Add pipenv to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
         libjpeg-progs optipng git vim curl
 
 # Supportive python tools for debugging, syntax checking and DB connectivity
-RUN pip3 install --upgrade pip ipdb flake8 python-swiftclient psycopg2 pymongo
+RUN pip3 install --upgrade pip ipdb flake8 python-swiftclient psycopg2 pymongo pipenv
 
 # Get nodejs
 RUN mkdir /usr/lib/nodejs && \


### PR DESCRIPTION
After looking into it I feel that [`pipenv`](https://docs.pipenv.org/basics/) is a great tool and the modern way to manage dependencies in Python projects, and we should switch to using it. Effectively this means all our `requirements.txt` files will instead become `Pipfile` and `Pipfile.lock` files.

The main benefit of this model is that we can install dependencies when we release based on a verified lockfile, including SHA hashes, allowing us to have greater confidence that the dependencies running in production are exactly what we intended.

Adding `pipenv` to this image is the first step, after which I'll update `generator-canonical-webteam`.

QA
--

``` bash
docker build --tag dev .  # Build the image
docker run dev pipenv install requests  # Check pipenv works
```