### PR TITLE
Upgrade the base image `ubuntu:bionic`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
 # Optimise environment variables
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8 NOKOGIRI_USE_SYSTEM_LIBRARIES=true
@@ -7,7 +7,7 @@ ENV LANG=C.UTF-8 LC_ALL=C.UTF-8 NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 RUN apt-get update && \
     apt-get install --yes \
         build-essential ruby-dev ruby-bundler python3-dev python3-pip \
-        libpq-dev libjpeg-dev zlib1g-dev libpng12-dev libmagickwand-dev \
+        libpq-dev libjpeg-dev zlib1g-dev libpng-dev libmagickwand-dev \
         libjpeg-progs optipng git vim curl jq python-launchpadlib libsodium-dev
 
 # Supportive python tools for debugging, syntax checking and DB connectivity

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A docker image as a basis for Canonical webteam's local development tools.
 
 ## Features
 
-- Based on ubuntu:xenial
+- Based on ubuntu:bionic
 - Python3
 - NodeJS version 6.11.3 LTS
 - Yarn


### PR DESCRIPTION
Upgrade the base image to Bionic for the latest LTS release, along with software updates.
This includes Python 3.5 upgrading to Python 3.6.


## QA
This can be tested by building the image:
`docker build . --tag canonicalwebteam/dev:bionic`

Then updating a ./run script to use the `canonicalwebteam/dev:bionic` tag and testing the site.