### PR TITLE
Symlink psudo home to root's home

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ ENV PATH=$NODEJS_HOME/bin:$PATH
 RUN npm install --global yarn bower
 
 # Create a shared home directory - this helps anonymous users have a home
+RUN ln -s /root /home/shared
+WORKDIR /home/shared
 ENV HOME=/home/shared LANG=C.UTF-8 LC_ALL=C.UTF-8
 RUN mkdir -p $HOME
 RUN mkdir -p $HOME/.cache/yarn/


### PR DESCRIPTION
Make a symlink for /home/shared to /root
This prevents errors from mismatched home folders when running
as the default root user. For example, ssh does not use the $HOME
variable and reads from the passwd file.

## QA

Build the image `docker build --tag docker-dev-test`

Test the image in a repo hich uses the run script and change the run script:
`dev_image="docker-dev-test"`

`./run` should continue to correctly function with no changes