### PR TITLE
Symlink .ssh rather than whole folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ ENV PATH=$NODEJS_HOME/bin:$PATH
 RUN npm install --global yarn bower
 
 # Create a shared home directory - this helps anonymous users have a home
-RUN ln -s /root /home/shared
 WORKDIR /home/shared
 ENV HOME=/home/shared LANG=C.UTF-8 LC_ALL=C.UTF-8
 RUN mkdir -p $HOME
@@ -34,3 +33,7 @@ RUN mkdir -p $HOME/.cache/yarn/
 RUN mkdir -p $HOME/.cache/bower/
 RUN chmod -R 777 $HOME
 
+# SSH agent finds up home using /etc/passwd
+# Fix for .ssh folder
+RUN mkdir -p $HOME/.ssh
+RUN ln -s $HOME/.ssh /root/.ssh


### PR DESCRIPTION
Previously, the /root folder was symlinked to /home/shared as not
all programs use the $HOME folder. This specifically was aimed
at the SSH agent which reads a user's home from /etc/passwd. This
change only symlinks the required .ssh folder.

The original change was added so that CircleCI could mount .ssh keys and use them to pull git repos.
I have tested this image as a PR and the tests are passing:
https://github.com/canonical-websites/snapcraft.io/pull/808

## QA 

Build the image `docker build --tag docker-dev-test`

Test the image in the snapcraft.io run script and modify the dev_image to:
`dev_image="docker-dev-test"`

`./run` should continue to correctly function with no changes
