### PR TITLE
Install nodejs via apt to get last LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,8 @@ RUN apt-get update && \
 # Supportive python tools for debugging, syntax checking and DB connectivity
 RUN pip3 install --upgrade ipdb flake8 python-swiftclient psycopg2 pymongo pipenv
 
-# Get nodejs
-RUN mkdir /usr/lib/nodejs && \
-    curl https://nodejs.org/dist/v6.11.3/node-v6.11.3-linux-x64.tar.xz | tar -xJ -C /usr/lib/nodejs && \
-    mv /usr/lib/nodejs/node-v6.11.3-linux-x64 /usr/lib/nodejs/node-v6.11.3
-
-# Set nodejs paths
-ENV NODEJS_HOME=/usr/lib/nodejs/node-v6.11.3
-ENV PATH=$NODEJS_HOME/bin:$PATH
+# Install node
+RUN apt-get install nodejs npm --yes
 
 # Latest Yarn package manager and bower
 RUN npm install --global yarn bower

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A docker image as a basis for Canonical webteam's local development tools.
 
 - Based on ubuntu:bionic
 - Python3
-- NodeJS version 6.11.3 LTS
+- NodeJS version 8.10.0 LTS
 - Yarn
 - Ruby
 


### PR DESCRIPTION
# Summary 

Install node js via apt to get the last LTS (v8.10.0) deployed on bionic

# QA

- `docker build --tag docker-dev-test .`
- On run script from s.io replace on line 45: `dev_image="docker-dev-test"`
- `./run`
- s.io should work as usual
- `./run exec bash`
- On the console check that node version is v8.10.0: `node -v`