### PR TITLE
WD-29963 - Run image as root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,19 +28,16 @@ ADD src src
 RUN pip3 install --break-system-packages ./src
 RUN rm -r /tmp/*
 
-USER ubuntu
+ENV PATH="/root/.local/bin:/root/.local/share/mise/shims:$PATH"
 
-# Install mise
-RUN curl https://mise.run  | sh
-ENV PATH="/home/ubuntu/.local/bin:/home/ubuntu/.local/share/mise/shims:$PATH"
-# Set Python 3.10 as default
-RUN mise use -g python@3.10
-# Install Node.js and package managers
-RUN mise use -g node@22
-RUN npm config set prefix "/home/ubuntu/.npm-global"
-ENV PATH="/home/ubuntu/.npm-global/bin:$PATH"
+RUN curl https://mise.run | sh && \
+    mise use -g python@3.10 && \
+    mise use -g node@22
 
-RUN npm install --global npm
-RUN npm install --global yarn
+ENV PATH="/root/.npm-global/bin:$PATH"
+
+RUN npm config set prefix "/root/.npm-global" && \
+    npm install --global npm && \
+    npm install --global yarn
 
 WORKDIR /home/ubuntu

--- a/src/setup.py
+++ b/src/setup.py
@@ -12,7 +12,7 @@ assert sys.version_info >= (
 
 setup(
     name="dotrun-docker",
-    version="1.4.0",
+    version="1.5.0",
     packages=["dotrun_docker"],
     install_requires=[
         "ipdb",


### PR DESCRIPTION
## Done

- Removed `USER ubuntu` from Dockerfile so that the container is run as root.
- This solves the issue of not being able to write in bound mounts with the corporate laptops. 

## How to QA

1. Check-out this branch
2. Build this image `docker build . --tag canonicalwebteam/dotrun-image:local`
3. Run this image `docker run -it -p 8004:8004 canonicalwebteam/dotrun-image:local /bin/bash`
4. Check that you are root with `whoami`
5. Run a project
  - `git clone https://github.com/canonical-web-and-design/snapcraft.io/`
  - `cd snapcraft.io`
  - `dotrun -p 5004:5004 `
  - Visit http://localhost:8004 and check that the website is running

## Issue / Card

Fixes https://github.com/canonical/dotrun/issues/134
Fixes [WD-29963](https://warthogs.atlassian.net/browse/WD-29963)


[WD-29963]: https://warthogs.atlassian.net/browse/WD-29963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ